### PR TITLE
Integrated Grafana and add custom dashboards

### DIFF
--- a/chat/load_test.sh
+++ b/chat/load_test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Number of requests you want to send in parallel
+N=10
+
+# Function to send request
+send_request() {
+  local req_num=$1
+  local user_id="user_${req_num}"
+
+  local payload=$(jq -n --arg uid "$user_id" '{
+    prompt: "Write me a short paragraph about Economics.",
+    max_tokens: 50,
+    user_id: $uid
+  }')
+
+  curl -s -X POST "http://localhost:8000/generate" \
+    -H "Content-Type: application/json" \
+    -d "$payload" > /dev/null
+}
+
+# Main loop
+for i in $(seq 1 $N); do
+  send_request "$i" &
+done
+
+# Wait for all background jobs to finish
+wait
+
+echo "Sent $N concurrent requests to localhost:8000/generate!"

--- a/chat/simulate_prod_load.sh
+++ b/chat/simulate_prod_load.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+ENDPOINT="http://localhost:8000/generate"
+PROMPT="Explain in simple terms what leveraged buyouts are."
+USERS=("user_0" "user_1" "user_2" "user_3" "user_4" "user_5" "user_6" "user_7" "user_8" "user_9")
+
+while true; do
+  # Randomly select a user
+  RANDOM_USER=${USERS[$RANDOM % ${#USERS[@]}]}
+
+  # Send the request
+  curl -X POST "$ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -d "{\"prompt\": \"$PROMPT\", \"max_tokens\": 100, \"user_id\": \"$RANDOM_USER\"}"
+
+  echo -e "\nSent request for $RANDOM_USER"
+
+  # Optional: short sleep to avoid hammering the server too fast
+  sleep 3
+done

--- a/main/README.md
+++ b/main/README.md
@@ -78,17 +78,20 @@ To view metrics collected, just go to http://localhost:8000/metrics
 6. Open Grafana Dashboard
 
 ```
-// Port-forward grafana port
+// Port-forward Grafana web UI
 kubectl port-forward svc/llm-monitoring-grafana 8080:80
+
+// You can also port-forward Prometheus web UI
+kubectl port-forward svc/llm-monitoring-kube-promet-prometheus 9090:9090
 ```
 
-Now, just open http://localhost:8080/. You will need to obtain a password from the secret:
+Now, just open http://localhost:8080/ for Grafana Web UI, or http://localhost:9090 for Prometheus Web UI. You will need to obtain a password from the secret:
 
 ```
 kubectl get secret llm-monitoring-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 ```
 
-Use the username "admin", and the password decoded from the secret above.
+Use the username "admin", and the password decoded from the secret above. You can now navigate to the Dashboard menu to see the custom dashboards for our application.
 
 ## Metrics Collected
 

--- a/main/app/main.py
+++ b/main/app/main.py
@@ -68,15 +68,13 @@ async def generate(request: PromptRequest):
             history = system_prompt + trimmed_history
 
         # Log metrics
-        REQUEST_LATENCY.observe(time.time() - start_time)
-        TIME_TO_FIRST_TOKEN.observe(ttft_end - ttft_start)
-        REQUEST_COUNT.inc()
-        TOKENS_INPUT.inc(len(input_tokens))
-        TOKENS_GENERATED.inc(len(output_tokens))
+        REQUEST_LATENCY.labels(user_id=user_id).observe(time.time() - start_time)
+        TIME_TO_FIRST_TOKEN.labels(user_id=user_id).observe(ttft_end - ttft_start)
+        REQUEST_COUNT.labels(user_id=user_id).inc()
+        TOKENS_INPUT.labels(user_id=user_id).inc(len(input_tokens))
+        TOKENS_GENERATED.labels(user_id=user_id).inc(len(output_tokens))
         TOKEN_LENGTH_INPUT.observe(len(input_tokens))
         TOKEN_LENGTH_OUTPUT.observe(len(output_tokens))
-
-        update_resource_metrics()
 
         return {"output": response_text}
 

--- a/main/app/metrics.py
+++ b/main/app/metrics.py
@@ -1,24 +1,94 @@
 from prometheus_client import Counter, Histogram, Gauge
 
-REQUEST_LATENCY = Histogram('llm_request_latency_seconds', 'Time spent processing entire request',
-                            buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0])
-TIME_TO_FIRST_TOKEN = Histogram('llm_time_to_first_token_seconds', 'Time to first token',
-                                buckets=[0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0])
-REQUEST_COUNT = Counter('llm_request_count', 'Total number of requests')
-TOKENS_GENERATED = Counter('llm_tokens_generated_total', 'Total number of tokens generated')
-TOKENS_INPUT = Counter('llm_tokens_input_total', 'Total number of input tokens processed')
-ERROR_COUNT = Counter('llm_error_count', 'Total number of failed requests')
-ERROR_TYPES = Counter('llm_error_types', 'Types of errors', ['error_type'])
+# Histograms (latency per user)
+REQUEST_LATENCY = Histogram(
+    'llm_request_latency_seconds',
+    'Time spent processing entire request',
+    ['user_id'],
+    buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0]
+)
+TIME_TO_FIRST_TOKEN = Histogram(
+    'llm_time_to_first_token_seconds',
+    'Time to first token',
+    ['user_id'],
+    buckets=[0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0]
+)
 
-TOKEN_LENGTH_INPUT = Histogram('llm_token_length_input', 'Input token lengths',
-                               buckets=[10, 50, 100, 250, 500, 1000, 2000])
-TOKEN_LENGTH_OUTPUT = Histogram('llm_token_length_output', 'Output token lengths',
-                                buckets=[10, 50, 100, 250, 500, 1000, 2000])
-GPU_MEMORY_USAGE = Gauge('llm_gpu_memory_usage_bytes', 'GPU memory usage in bytes')
-CPU_USAGE_PERCENT = Gauge('llm_cpu_usage_percent', 'CPU usage percentage')
-RAM_USAGE_BYTES = Gauge('llm_ram_usage_bytes', 'RAM usage in bytes')
-QUEUE_TIME = Histogram('llm_queue_time_seconds', 'Time in queue',
-                       buckets=[0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0])
-QUEUE_SIZE = Gauge('llm_queue_size', 'Current request queue size')
-RATE_LIMIT_BREACHES = Counter('llm_rate_limit_breaches', 'Rate limit breaches', ['user_id'])
-THROTTLING_INCIDENTS = Counter('llm_throttling_incidents', 'Throttling incidents')
+# Counters (request and token counters per user)
+REQUEST_COUNT = Counter(
+    'llm_request_count',
+    'Total number of requests',
+    ['user_id']
+)
+TOKENS_GENERATED = Counter(
+    'llm_tokens_generated_total',
+    'Total number of tokens generated',
+    ['user_id']
+)
+TOKENS_INPUT = Counter(
+    'llm_tokens_input_total',
+    'Total number of input tokens processed',
+    ['user_id']
+)
+ERROR_COUNT = Counter(
+    'llm_error_count',
+    'Total number of failed requests',
+    ['user_id']
+)
+
+# Counter for error types
+ERROR_TYPES = Counter(
+    'llm_error_types',
+    'Types of errors',
+    ['error_type']
+)
+
+# Histograms for token length
+TOKEN_LENGTH_INPUT = Histogram(
+    'llm_token_length_input',
+    'Input token lengths',
+    buckets=[10, 50, 100, 250, 500, 1000, 2000]
+)
+TOKEN_LENGTH_OUTPUT = Histogram(
+    'llm_token_length_output',
+    'Output token lengths',
+    buckets=[10, 50, 100, 250, 500, 1000, 2000]
+)
+
+# Memory Usage
+GPU_MEMORY_USAGE = Gauge(
+    'llm_gpu_memory_usage_bytes',
+    'GPU memory usage in bytes'
+)
+CPU_USAGE_PERCENT = Gauge(
+    'llm_cpu_usage_percent',
+    'CPU usage percentage'
+)
+RAM_USAGE_BYTES = Gauge(
+    'llm_ram_usage_bytes',
+    'RAM usage in bytes'
+)
+
+# Histogram for queue time
+QUEUE_TIME = Histogram(
+    'llm_queue_time_seconds',
+    'Time in queue',
+    buckets=[0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0]
+)
+
+# Queue size
+QUEUE_SIZE = Gauge(
+    'llm_queue_size',
+    'Current request queue size'
+)
+
+# Counters with user labels
+RATE_LIMIT_BREACHES = Counter(
+    'llm_rate_limit_breaches',
+    'Rate limit breaches',
+    ['user_id']
+)
+THROTTLING_INCIDENTS = Counter(
+    'llm_throttling_incidents',
+    'Throttling incidents'
+)

--- a/main/charts/llm-monitoring-chart/templates/dashboards/grafana-dashboard-global.yaml
+++ b/main/charts/llm-monitoring-chart/templates/dashboards/grafana-dashboard-global.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: llm-global-dashboard
+    labels:
+        grafana_dashboard: "1"
+data:
+    llm-global-dashboard.json: |
+        {
+          "uid": "llm-global-dashboard",
+          "title": "LLM Global Metrics",
+          "schemaVersion": 37,
+          "version": 3,
+          "panels": [
+            { "title": "Total Requests", "type": "timeseries", "fieldConfig": {"defaults": {"custom": {"axisLabel": "Requests"}}}, "targets": [ { "expr": "sum(llm_request_count_total)" } ], "gridPos": {"x":0,"y":0,"w":12,"h":8} },
+            { "title": "Average Request Latency", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "s", "custom": {"axisLabel": "Latency"}}}, "targets": [ { "expr": "sum(rate(llm_request_latency_seconds_sum[1m])) / sum(rate(llm_request_latency_seconds_count[1m]))" } ], "gridPos": {"x":12,"y":0,"w":12,"h":8} },
+            { "title": "Average Time to First Token", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "s", "custom": {"axisLabel": "Time to First Token (s)"}}}, "targets": [ { "expr": "sum(rate(llm_time_to_first_token_seconds_sum[1m])) / sum(rate(llm_time_to_first_token_seconds_count[1m]))" } ], "gridPos": {"x":0,"y":8,"w":12,"h":8} },
+            { "title": "Tokens Generated", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "tokens", "custom": {"axisLabel": "Tokens"}}}, "targets": [ { "expr": "sum(increase(llm_tokens_generated_total[5m]))" } ], "gridPos": {"x":12,"y":8,"w":12,"h":8} },
+            { "title": "Inference Error Rate", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "errors/s", "custom": {"axisLabel": "Errors per Second"}}}, "targets": [ { "expr": "sum(rate(llm_error_count_total[1m]))" } ], "gridPos": {"x":0,"y":16,"w":12,"h":8} },
+            { "title": "Rate Limit Breaches", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "breaches/s", "custom": {"axisLabel": "Breaches per Second"}}}, "targets": [ { "expr": "sum(rate(llm_rate_limit_breaches_total[1m]))" } ], "gridPos": {"x":12,"y":16,"w":12,"h":8} }
+          ]
+        }

--- a/main/charts/llm-monitoring-chart/templates/dashboards/grafana-dashboard-peruser.yaml
+++ b/main/charts/llm-monitoring-chart/templates/dashboards/grafana-dashboard-peruser.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: llm-peruser-dashboard
+    labels:
+        grafana_dashboard: "1"
+data:
+    llm-peruser-dashboard.json: |
+        {
+          "uid": "llm-peruser-dashboard",
+          "title": "LLM Metrics Per User",
+          "schemaVersion": 37,
+          "version": 2,
+          "templating": { "list": [ { "name": "user_id", "type": "query", "datasource": "Prometheus", "refresh": 1, "query": "label_values(llm_request_count_total, user_id)", "multi": true, "includeAll": true, "current": { "text": "All", "value": "$__all" }} ] },
+          "panels": [
+            { "title": "User Requests", "type": "timeseries", "fieldConfig": {"defaults": {"custom": {"axisLabel": "Requests"}}}, "targets": [ { "expr": "llm_request_count_total{user_id=~\"$user_id\"}" } ], "gridPos": {"x":0,"y":0,"w":12,"h":8} },
+            { "title": "User Request Latency", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "s", "custom": {"axisLabel": "Latency"}}}, "targets": [ { "expr": "rate(llm_request_latency_seconds_sum{user_id=~\"$user_id\"}[1m]) / rate(llm_request_latency_seconds_count{user_id=~\"$user_id\"}[1m])" } ], "gridPos": {"x":12,"y":0,"w":12,"h":8} },
+            { "title": "User Tokens Generated", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "tokens", "custom": {"axisLabel": "Tokens"}}}, "targets": [ { "expr": "increase(llm_tokens_generated_total{user_id=~\"$user_id\"}[5m])" } ], "gridPos": {"x":0,"y":8,"w":12,"h":8} },
+            { "title": "User Error Rate", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "errors/s", "custom": {"axisLabel": "Errors per Second"}}}, "targets": [ { "expr": "rate(llm_error_count_total{user_id=~\"$user_id\"}[1m])" } ], "gridPos": {"x":12,"y":8,"w":12,"h":8} },
+            { "title": "User Rate Limit Breaches", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "breaches/s", "custom": {"axisLabel": "Breaches per Second"}}}, "targets": [ { "expr": "rate(llm_rate_limit_breaches{user_id=~\"$user_id\"}[1m])" } ], "gridPos": {"x":0,"y":16,"w":24,"h":8} }
+          ]
+        }

--- a/main/charts/llm-monitoring-chart/templates/dashboards/grafana-dashboard-system.yaml
+++ b/main/charts/llm-monitoring-chart/templates/dashboards/grafana-dashboard-system.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: llm-system-dashboard
+    labels:
+        grafana_dashboard: "1"
+data:
+    llm-system-dashboard.json: |
+        {
+          "uid": "llm-system-dashboard",
+          "title": "LLM System Resource Metrics",
+          "schemaVersion": 37,
+          "version": 2,
+          "panels": [
+            { "title": "CPU Usage %", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "percent", "custom": {"axisLabel": "CPU Usage %"}}}, "targets": [ { "expr": "llm_cpu_usage_percent" } ], "gridPos": {"x":0,"y":0,"w":12,"h":8} },
+            { "title": "RAM Usage Bytes", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "bytes", "custom": {"axisLabel": "RAM Usage (bytes)"}}}, "targets": [ { "expr": "llm_ram_usage_bytes" } ], "gridPos": {"x":12,"y":0,"w":12,"h":8} },
+            { "title": "GPU Memory Usage", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "bytes", "custom": {"axisLabel": "GPU Memory (bytes)"}}}, "targets": [ { "expr": "llm_gpu_memory_usage_bytes" } ], "gridPos": {"x":0,"y":8,"w":12,"h":8} },
+            { "title": "Queue Size", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "short", "custom": {"axisLabel": "Queue Size"}}}, "targets": [ { "expr": "llm_queue_size" } ], "gridPos": {"x":12,"y":8,"w":12,"h":8} },
+            { "title": "Queue Time", "type": "timeseries", "fieldConfig": {"defaults": {"unit": "s", "custom": {"axisLabel": "Queue Time (s)"}}}, "targets": [ { "expr": "rate(llm_queue_time_seconds_sum[1m]) / rate(llm_queue_time_seconds_count[1m])" } ], "gridPos": {"x":0,"y":16,"w":24,"h":8} }
+          ]
+        }

--- a/main/charts/llm-monitoring-chart/templates/service-monitor.yaml
+++ b/main/charts/llm-monitoring-chart/templates/service-monitor.yaml
@@ -1,17 +1,17 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: llm-monitoring-servicemonitor
+  name: {{ .Release.Name }}-servicemonitor
   labels:
-    release: prometheus
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: llm-monitoring
+      app: {{ .Release.Name }}
   endpoints:
     - port: http
       path: /metrics
       interval: 15s
   namespaceSelector:
     matchNames:
-      - default
+      - {{ .Release.Namespace }}

--- a/main/charts/llm-monitoring-chart/templates/service.yaml
+++ b/main/charts/llm-monitoring-chart/templates/service.yaml
@@ -1,13 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-    name: {{ .Release.Name }}
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app: {{ .Release.Name }}
+    release: prometheus
 spec:
-    type: {{ .Values.service.type }}
-    ports:
-        - port: {{ .Values.service.port }}
-          targetPort: 8000
-          protocol: TCP
-          name: http
-    selector:
-        app: {{ .Release.Name }}
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Release.Name }}

--- a/main/charts/llm-monitoring-chart/values.yaml
+++ b/main/charts/llm-monitoring-chart/values.yaml
@@ -27,3 +27,8 @@ kube-prometheus-stack:
         defaultDashboardsEnabled: true
         service:
             type: LoadBalancer
+        sidecar:
+            dashboards:
+                enabled: true
+                searchNamespace: default
+                waitForGrafana: true


### PR DESCRIPTION
- Successfully integrated Prometheus /metric endpoint with Grafana
- Added 3 custom dashboards (general aggregated LLM metrics, user-level LLM metrics, and system metrics)
- Added bash scripts to send requests to endpoint to simulate real prod traffic